### PR TITLE
Add a rule for checking for Google identity providers

### DIFF
--- a/rules/platform/identity-provider-google.yaml
+++ b/rules/platform/identity-provider-google.yaml
@@ -1,0 +1,13 @@
+---
+kind: Rule
+checkType: Platform
+title: Verify the cluster is configured to use Google as an identity provider
+expression: "identityProvider.spec.identityProviders.exists_one(e, e.type == 'Google')"
+inputs:
+  - name: identityProvider
+    type: KubeGroupVersionResource
+    apiGroup: config.openshift.io
+    version: v1
+    resource: oauths
+    subResource: cluster
+errorMessage: Google is not configured as an identity provider


### PR DESCRIPTION
This is just an example of how to use CEL differently for checking a
specific idp case.
