### PR TITLE
Support evaluating lists in CEL

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,10 +99,18 @@ func main() {
 	fmt.Printf("Evaluation result: %v\n", out)
 }
 
-// toCelValue converts an unstructured.Unstructured object to a format compatible with CEL
-func toCelValue(u interface{}) map[string]interface{} {
+func toCelValue(u interface{}) interface{} {
 	if unstruct, ok := u.(*unstructured.Unstructured); ok {
 		return unstruct.Object
+	}
+	if unstructList, ok := u.(*unstructured.UnstructuredList); ok {
+		list := []interface{}{}
+		for _, item := range unstructList.Items {
+			list = append(list, item.Object)
+		}
+		return map[string]interface{}{
+			"items": list,
+		}
 	}
 	return nil
 }

--- a/rules/platform/ssc-required-drop-capabilities.yaml
+++ b/rules/platform/ssc-required-drop-capabilities.yaml
@@ -1,0 +1,13 @@
+---
+# Implements CIS OpenShift Control X.Y.Z
+kind: Rule
+checkType: Platform
+title: Verify there is at least one Security Context Constraint that drops all container capabilities
+expression: securityContextConstraints.exists(e, e.requiredDropCapabilities == ['ALL'])
+inputs:
+  - name: securityContextConstraints
+    type: KubeGroupVersionResource
+    apiGroup: security.openshift.io
+    version: v1
+    resource: securitycontextconstraints
+errorMessage: No Security Context Constraint exists that drops all capabilities


### PR DESCRIPTION
Previously, we were type checking the unstructured.Unstructured value
from the kubeclient, and then passing that into the CEL program. This
commit expands on that concept to include UnstructuredLists, so that we
can write CEL expressions that operate on iterables.
