### PR TITLE
Fix scc rule, the expression is not accessing the list.

### DIFF
--- a/rules/platform/scc-required-drop-capabilities.yaml
+++ b/rules/platform/scc-required-drop-capabilities.yaml
@@ -3,7 +3,7 @@
 kind: Rule
 checkType: Platform
 title: Verify there is at least one Security Context Constraint that drops all container capabilities
-expression: securityContextConstraints.exists(e, e.requiredDropCapabilities == ['ALL'])
+expression: securityContextConstraints.items.exists(e, e.requiredDropCapabilities == ['ALL'])
 inputs:
   - name: securityContextConstraints
     type: KubeGroupVersionResource


### PR DESCRIPTION
Without this fix I get `requiredDropCapabilities` key not found:

`Warning: no such key: requiredDropCapabilities in securitycontextconstraints/`