### PR TITLE
Simplify scan output when using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,2 @@
 all:
-	go run main.go -i rules/platform/etcd-cert-file.yaml
-	go run main.go -i rules/platform/token-based-authentication-disabled.yaml
-	go run main.go -i rules/platform/scc-required-drop-capabilities.yaml
-	go run main.go -i rules/platform/image-provenance.yaml
-	go run main.go -i rules/platform/identity-provider-google.yaml
-	go run main.go -i rules/platform/identity-provider-configuration.yaml
-	go run main.go -i rules/platform/network-policy.yaml
+	./scan.sh

--- a/scan.sh
+++ b/scan.sh
@@ -1,0 +1,7 @@
+go run main.go -i rules/platform/etcd-cert-file.yaml
+go run main.go -i rules/platform/token-based-authentication-disabled.yaml
+go run main.go -i rules/platform/scc-required-drop-capabilities.yaml
+go run main.go -i rules/platform/image-provenance.yaml
+go run main.go -i rules/platform/identity-provider-google.yaml
+go run main.go -i rules/platform/identity-provider-configuration.yaml
+go run main.go -i rules/platform/network-policy.yaml


### PR DESCRIPTION
Put all the scripts into a single executable and run from there, so we
only get the scan output, instead of the go invocation.
