### PR TITLE
Fix typo in etcd

### DIFF
--- a/rules/node/etcd-data-ownership.yaml
+++ b/rules/node/etcd-data-ownership.yaml
@@ -3,9 +3,9 @@
 kind: Rule
 checkType: Node
 title: Ensure the etcd data directory belongs to etcd user
-expression: ectcd_file.group == etcd && ectcd_file.owner == etcd
+expression: etcd_file.group == etcd && etcd_file.owner == etcd
 inputs:
-  - name: ectcd_file
+  - name: etcd_file
     type: File
     path: /host/var/lib/etcd
 errorMessage: The etcd data directory does not belong to the etcd user.

--- a/rules/node/etcd-data-permissions.yaml
+++ b/rules/node/etcd-data-permissions.yaml
@@ -3,9 +3,9 @@
 kind: Rule
 checkType: Node
 title: Ensure the etcd data directory permissions are 0700
-expression: ectcd_file.mode == 0700
+expression: etcd_file.mode == 0700
 inputs:
-  - name: ectcd_file
+  - name: etcd_file
     type: File
     path: /host/var/lib/etcd
 errorMessage: The etcd data directory does not have 0700 permissions.


### PR DESCRIPTION
Fixes typo in name of the file 'ect' vs 'etc'